### PR TITLE
Add admin layout components and navigation system

### DIFF
--- a/uikit/src/admin/components/Loader.jsx
+++ b/uikit/src/admin/components/Loader.jsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// @mui
+import LinearProgress from '@mui/material/LinearProgress';
+import Box from '@mui/material/Box';
+
+/***************************  LOADER  ***************************/
+
+export default function Loader() {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  return (
+    <>
+      {isClient && (
+        <Box sx={{ position: 'fixed', top: 0, left: 0, zIndex: 2001, width: '100%' }}>
+          <LinearProgress variant="indeterminate" color="primary" />
+        </Box>
+      )}
+    </>
+  );
+}

--- a/uikit/src/admin/components/MainCard.jsx
+++ b/uikit/src/admin/components/MainCard.jsx
@@ -1,0 +1,32 @@
+'use client';
+import PropTypes from 'prop-types';
+
+// @mui
+import Card from '@mui/material/Card';
+
+export default function MainCard({ children, sx = {}, ref, ...others }) {
+  const defaultSx = (theme) => ({
+    p: { xs: 1.75, sm: 2.25, md: 3 },
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: 4,
+    boxShadow: theme.customShadows?.section || '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
+  });
+
+  const combinedSx = (theme) => ({
+    ...defaultSx(theme),
+    ...(typeof sx === 'function' ? sx(theme) : sx)
+  });
+
+  return (
+    <Card ref={ref} elevation={0} sx={combinedSx} {...others}>
+      {children}
+    </Card>
+  );
+}
+
+MainCard.propTypes = {
+  children: PropTypes.any,
+  sx: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  ref: PropTypes.any,
+  others: PropTypes.any
+};

--- a/uikit/src/admin/components/cards/OverviewCard.jsx
+++ b/uikit/src/admin/components/cards/OverviewCard.jsx
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+// @mui
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+// @project
+import MainCard from '../MainCard';
+
+/***************************   CARD - OVERVIEW   ***************************/
+
+export default function OverviewCard({ title, value, chip, compare, cardProps }) {
+  const chipDefaultProps = { color: 'success', variant: 'text', size: 'small' };
+
+  return (
+    <MainCard {...cardProps}>
+      <Stack sx={{ gap: { xs: 3, md: 4 } }}>
+        <Typography variant="subtitle1">{title}</Typography>
+        <Stack sx={{ gap: 0.5 }}>
+          <Stack direction="row" sx={{ gap: 1, alignItems: 'center' }}>
+            <Typography variant="h4">{value}</Typography>
+            <Chip {...{ ...chipDefaultProps, ...chip }} />
+          </Stack>
+          <Typography variant="caption" color="grey.700">
+            {compare}
+          </Typography>
+        </Stack>
+      </Stack>
+    </MainCard>
+  );
+}
+
+OverviewCard.propTypes = {
+  title: PropTypes.string,
+  value: PropTypes.string,
+  chip: PropTypes.any,
+  compare: PropTypes.string,
+  cardProps: PropTypes.any
+};

--- a/uikit/src/admin/config.js
+++ b/uikit/src/admin/config.js
@@ -1,0 +1,56 @@
+// @next
+import { Archivo } from 'next/font/google';
+
+/***************************  THEME CONSTANT  ***************************/
+
+export const APP_DEFAULT_PATH = '/admin/dashboard';
+
+export const DRAWER_WIDTH = 254;
+export const MINI_DRAWER_WIDTH = 76 + 1; // 1px - for right-side border
+
+/***************************  THEME ENUM  ***************************/
+
+export let Themes;
+
+(function (Themes) {
+  Themes['THEME_HOSTING'] = 'hosting';
+})(Themes || (Themes = {}));
+
+export let ThemeMode;
+
+(function (ThemeMode) {
+  ThemeMode['LIGHT'] = 'light';
+})(ThemeMode || (ThemeMode = {}));
+
+export let ThemeDirection;
+
+(function (ThemeDirection) {
+  ThemeDirection['LTR'] = 'ltr';
+})(ThemeDirection || (ThemeDirection = {}));
+
+export let ThemeI18n;
+
+(function (ThemeI18n) {
+  ThemeI18n['EN'] = 'en';
+  ThemeI18n['FR'] = 'fr';
+  ThemeI18n['RO'] = 'ro';
+  ThemeI18n['ZH'] = 'zh';
+})(ThemeI18n || (ThemeI18n = {}));
+
+/***************************  CONFIG  ***************************/
+
+const config = {
+  currentTheme: Themes.THEME_HOSTING,
+  mode: ThemeMode.LIGHT,
+  themeDirection: ThemeDirection.LTR,
+  miniDrawer: false,
+  i18n: ThemeI18n.EN
+};
+
+export default config;
+
+/***************************  THEME - FONT FAMILY  ***************************/
+
+const fontArchivo = Archivo({ subsets: ['latin'], display: 'swap', weight: ['400', '500', '600', '700'] });
+
+export const FONT_ARCHIVO = fontArchivo.style.fontFamily;

--- a/uikit/src/admin/data/menu.js
+++ b/uikit/src/admin/data/menu.js
@@ -1,0 +1,51 @@
+/***************************  MENU ITEMS - ADMIN  ***************************/
+
+const adminMenu = {
+  id: 'group-admin',
+  title: 'Admin',
+  icon: 'IconBrandAsana',
+  type: 'group',
+  children: [
+    {
+      id: 'dashboard',
+      title: 'Dashboard',
+      type: 'item',
+      url: '/admin/dashboard',
+      icon: 'IconLayoutGrid'
+    },
+    {
+      id: 'users',
+      title: 'Users',
+      type: 'item',
+      url: '/admin/users',
+      icon: 'IconUsers'
+    },
+    {
+      id: 'content',
+      title: 'Content',
+      type: 'item',
+      url: '/admin/content',
+      icon: 'IconFileText'
+    },
+    {
+      id: 'analytics',
+      title: 'Analytics',
+      type: 'item',
+      url: '/admin/analytics',
+      icon: 'IconChartBar'
+    },
+    {
+      id: 'settings',
+      title: 'Settings',
+      type: 'item',
+      url: '/admin/settings',
+      icon: 'IconSettings'
+    }
+  ]
+};
+
+const menuItems = {
+  items: [adminMenu]
+};
+
+export default menuItems;

--- a/uikit/src/admin/guards/AdminGuard.jsx
+++ b/uikit/src/admin/guards/AdminGuard.jsx
@@ -1,0 +1,49 @@
+'use client';
+import PropTypes from 'prop-types';
+import { redirect } from 'next/navigation';
+
+// Mock auth hook - replace with your actual auth implementation
+function useAuth() {
+  // This should be replaced with your actual auth implementation
+  // For now, returning a mock admin user
+  return {
+    user: {
+      id: '1',
+      name: 'Admin User',
+      email: 'admin@example.com',
+      role: 'ADMIN'
+    },
+    isAuthenticated: true,
+    isLoading: false
+  };
+}
+
+/***************************  ADMIN GUARD  ***************************/
+
+export default function AdminGuard({ children, fallback = null }) {
+  const { user, isAuthenticated, isLoading } = useAuth();
+
+  // Show loading while checking authentication
+  if (isLoading) {
+    return fallback || <div>Loading...</div>;
+  }
+
+  // Redirect to login if not authenticated
+  if (!isAuthenticated) {
+    redirect('/auth/login');
+    return null;
+  }
+
+  // Check if user has admin role
+  if (user?.role !== 'ADMIN') {
+    redirect('/auth/unauthorized');
+    return null;
+  }
+
+  return children;
+}
+
+AdminGuard.propTypes = {
+  children: PropTypes.node.isRequired,
+  fallback: PropTypes.node
+};

--- a/uikit/src/admin/hooks/useMenuState.js
+++ b/uikit/src/admin/hooks/useMenuState.js
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+
+// @third-party
+import useSWR, { mutate } from 'swr';
+
+const initialState = {
+  openedItem: '',
+  isDashboardDrawerOpened: true
+};
+
+export const endpoints = {
+  key: 'api/admin/menu',
+  master: 'master'
+};
+
+export function useGetMenuMaster() {
+  // to fetch initial state based on endpoints
+
+  const { data, isLoading } = useSWR(endpoints.key + endpoints.master, () => initialState, {
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false
+  });
+
+  const memoizedValue = useMemo(
+    () => ({
+      menuMaster: data,
+      menuMasterLoading: isLoading
+    }),
+    [data, isLoading]
+  );
+
+  return memoizedValue;
+}
+
+export function handlerDrawerOpen(isDashboardDrawerOpened) {
+  // to update `isDashboardDrawerOpened` local state based on key
+
+  mutate(
+    endpoints.key + endpoints.master,
+    (currentMenuMaster = initialState) => {
+      return { ...currentMenuMaster, isDashboardDrawerOpened };
+    },
+    false
+  );
+}
+
+export function handlerActiveItem(openedItem) {
+  // to update `openedItem` local state based on key
+
+  mutate(
+    endpoints.key + endpoints.master,
+    (currentMenuMaster = initialState) => {
+      return { ...currentMenuMaster, openedItem };
+    },
+    false
+  );
+}

--- a/uikit/src/admin/layouts/AdminDrawer.jsx
+++ b/uikit/src/admin/layouts/AdminDrawer.jsx
@@ -1,0 +1,163 @@
+import PropTypes from 'prop-types';
+import { useMemo } from 'react';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
+import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Typography from '@mui/material/Typography';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+// @project
+import { handlerDrawerOpen, useGetMenuMaster } from '../hooks/useMenuState';
+import { DRAWER_WIDTH } from '../config';
+import menuItems from '../data/menu';
+
+// @assets
+import { IconLayoutGrid, IconUsers, IconFileText, IconChartBar, IconSettings, IconBrandAsana } from '@tabler/icons-react';
+
+const iconMap = {
+  IconLayoutGrid,
+  IconUsers,
+  IconFileText,
+  IconChartBar,
+  IconSettings,
+  IconBrandAsana
+};
+
+/***************************  ADMIN LAYOUT - DRAWER  ***************************/
+
+function DrawerHeader({ open }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', p: 2 }}>
+      <Typography variant="h6" noWrap component="div">
+        {open ? 'Admin Panel' : 'AP'}
+      </Typography>
+    </Box>
+  );
+}
+
+function DrawerContent() {
+  const pathname = usePathname();
+
+  const renderMenuItem = (item) => {
+    const IconComponent = iconMap[item.icon] || IconLayoutGrid;
+    const isActive = pathname === item.url;
+
+    return (
+      <ListItem key={item.id} disablePadding>
+        <ListItemButton
+          component={Link}
+          href={item.url}
+          sx={{
+            minHeight: 48,
+            justifyContent: 'initial',
+            px: 2.5,
+            backgroundColor: isActive ? 'primary.lighter' : 'transparent',
+            color: isActive ? 'primary.main' : 'inherit',
+            '&:hover': {
+              backgroundColor: 'primary.lighter'
+            }
+          }}
+        >
+          <ListItemIcon
+            sx={{
+              minWidth: 0,
+              mr: 3,
+              justifyContent: 'center',
+              color: isActive ? 'primary.main' : 'inherit'
+            }}
+          >
+            <IconComponent size={20} />
+          </ListItemIcon>
+          <ListItemText primary={item.title} />
+        </ListItemButton>
+      </ListItem>
+    );
+  };
+
+  return (
+    <Box sx={{ overflow: 'auto' }}>
+      {menuItems.items.map((group) => (
+        <Box key={group.id}>
+          <Typography variant="overline" sx={{ px: 2.5, py: 1, display: 'block' }}>
+            {group.title}
+          </Typography>
+          <List>{group.children?.map(renderMenuItem)}</List>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+export default function AdminDrawer({ window }) {
+  const { menuMaster } = useGetMenuMaster();
+  const drawerOpen = menuMaster.isDashboardDrawerOpened;
+  const downLG = useMediaQuery((theme) => theme.breakpoints.down('lg'));
+
+  // Define container for drawer when window is specified
+  const container = window !== undefined ? () => window().document.body : undefined;
+
+  // Memoize drawer content and header to prevent unnecessary re-renders
+  const drawerContent = useMemo(() => <DrawerContent />, []);
+  const drawerHeader = useMemo(() => <DrawerHeader open={drawerOpen} />, [drawerOpen]);
+
+  const drawerSx = {
+    width: DRAWER_WIDTH,
+    flexShrink: 0,
+    '& .MuiDrawer-paper': {
+      width: DRAWER_WIDTH,
+      boxSizing: 'border-box',
+      borderRight: '1px solid',
+      borderRightColor: 'divider',
+      backgroundImage: 'none',
+      boxShadow: 'inherit'
+    }
+  };
+
+  return (
+    <Box component="nav" sx={{ flexShrink: { md: 0 }, zIndex: 1200 }} aria-label="admin navigation">
+      {/* Temporary drawer for small media */}
+      <Drawer
+        container={container}
+        variant="temporary"
+        open={drawerOpen && downLG}
+        onClose={() => handlerDrawerOpen(!drawerOpen)}
+        ModalProps={{
+          keepMounted: true // Better open performance on mobile.
+        }}
+        sx={{
+          display: { xs: 'block', lg: 'none' },
+          ...drawerSx
+        }}
+      >
+        {drawerHeader}
+        <Divider />
+        {drawerContent}
+      </Drawer>
+
+      {/* Permanent drawer for large media */}
+      <Drawer
+        variant="permanent"
+        sx={{
+          display: { xs: 'none', lg: 'block' },
+          ...drawerSx
+        }}
+        open
+      >
+        {drawerHeader}
+        <Divider />
+        {drawerContent}
+      </Drawer>
+    </Box>
+  );
+}
+
+AdminDrawer.propTypes = { window: PropTypes.func };
+DrawerHeader.propTypes = { open: PropTypes.bool };

--- a/uikit/src/admin/layouts/AdminHeader.jsx
+++ b/uikit/src/admin/layouts/AdminHeader.jsx
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+
+// @mui
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import AppBar from '@mui/material/AppBar';
+import IconButton from '@mui/material/IconButton';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+// @project
+import { handlerDrawerOpen, useGetMenuMaster } from '../hooks/useMenuState';
+import { DRAWER_WIDTH } from '../config';
+
+// @assets
+import { IconLayoutSidebarRightCollapse, IconMenu2 } from '@tabler/icons-react';
+
+/***************************  ADMIN LAYOUT - HEADER  ***************************/
+
+export default function AdminHeader() {
+  const theme = useTheme();
+  const downLG = useMediaQuery(theme.breakpoints.down('lg'));
+
+  const { menuMaster } = useGetMenuMaster();
+  const drawerOpen = menuMaster.isDashboardDrawerOpened;
+
+  // Common header content
+  const mainHeader = (
+    <Toolbar sx={{ minHeight: { xs: 68, md: 76 } }}>
+      <IconButton
+        aria-label="open drawer"
+        onClick={() => handlerDrawerOpen(!drawerOpen)}
+        size="small"
+        color="secondary"
+        variant="outlined"
+        sx={{ display: { xs: 'inline-flex', lg: !drawerOpen ? 'inline-flex' : 'none' }, mr: 1 }}
+      >
+        <>
+          {!drawerOpen && !downLG && <IconLayoutSidebarRightCollapse size={20} />}
+          {downLG && <IconMenu2 size={20} />}
+        </>
+      </IconButton>
+
+      <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+        Admin Dashboard
+      </Typography>
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {/* Add user menu, notifications, etc here */}
+        <Typography variant="body2" color="text.secondary">
+          Welcome, Admin
+        </Typography>
+      </Box>
+    </Toolbar>
+  );
+
+  // AppBar props, including styles that vary based on drawer state and screen size
+  const appBarProps = {
+    color: 'inherit',
+    position: 'fixed',
+    elevation: 0,
+    sx: {
+      borderBottom: `1px solid ${theme.palette.grey[300]}`,
+      zIndex: 1200,
+      width: { xs: '100%', lg: drawerOpen ? `calc(100% - ${DRAWER_WIDTH}px)` : 1 }
+    }
+  };
+
+  return <AppBar {...appBarProps}>{mainHeader}</AppBar>;
+}

--- a/uikit/src/admin/layouts/AdminLayout.jsx
+++ b/uikit/src/admin/layouts/AdminLayout.jsx
@@ -1,0 +1,65 @@
+'use client';
+import PropTypes from 'prop-types';
+
+import { useEffect } from 'react';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
+import Container from '@mui/material/Container';
+import Toolbar from '@mui/material/Toolbar';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+
+// @project
+import AdminDrawer from './AdminDrawer';
+import AdminHeader from './AdminHeader';
+import { handlerDrawerOpen, useGetMenuMaster } from '../hooks/useMenuState';
+import AdminBreadcrumbs from './AdminBreadcrumbs';
+import Loader from '../components/Loader';
+import AdminGuard from '../guards/AdminGuard';
+
+import { DRAWER_WIDTH } from '../config';
+
+/***************************  ADMIN LAYOUT  ***************************/
+
+export default function AdminLayout({ children }) {
+  const { menuMasterLoading } = useGetMenuMaster();
+
+  const downXL = useMediaQuery((theme) => theme.breakpoints.down('xl'));
+
+  useEffect(() => {
+    handlerDrawerOpen(!downXL);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [downXL]);
+
+  if (menuMasterLoading) return <Loader />;
+
+  return (
+    <AdminGuard>
+      <Stack direction="row" width={1}>
+        <AdminHeader />
+        <AdminDrawer />
+        <Box component="main" sx={{ width: `calc(100% - ${DRAWER_WIDTH}px)`, flexGrow: 1, p: { xs: 2, sm: 3 } }}>
+          <Toolbar sx={{ minHeight: { xs: 54, sm: 46, md: 76 } }} />
+          <Box
+            sx={{
+              py: 0.4,
+              px: 1.5,
+              mx: { xs: -2, sm: -3 },
+              display: { xs: 'block', md: 'none' },
+              borderBottom: 1,
+              borderColor: 'divider',
+              mb: 2
+            }}
+          >
+            <AdminBreadcrumbs />
+          </Box>
+          <Container maxWidth="lg" sx={{ px: { xs: 0, sm: 2 } }}>
+            {children}
+          </Container>
+        </Box>
+      </Stack>
+    </AdminGuard>
+  );
+}
+
+AdminLayout.propTypes = { children: PropTypes.any };


### PR DESCRIPTION
Add comprehensive admin layout system with the following components:

**Layout Components:**
- AdminLayout: Main layout wrapper with responsive design
- AdminHeader: Fixed header with drawer toggle and user info
- AdminDrawer: Collapsible navigation sidebar with menu items
- AdminBreadcrumbs: Navigation breadcrumb component

**UI Components:**
- Loader: Fixed position loading indicator with client-side rendering
- MainCard: Reusable card component with customizable styling
- OverviewCard: Statistics card with title, value, chip and comparison

**Navigation & State:**
- useMenuState hook: SWR-based menu state management
- Menu data structure with admin navigation items
- Responsive drawer behavior for mobile and desktop

**Configuration:**
- Theme constants and enums for hosting theme
- Font configuration with Archivo font family
- Drawer width and layout constants

**Security:**
- AdminGuard: Route protection component with role-based access
- Mock authentication implementation for admin users

All components use Material-UI and include proper PropTypes validation.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d76b23fd9cbb4d078d0dc063649c0467/zen-verse)

👀 [Preview Link](https://d76b23fd9cbb4d078d0dc063649c0467-zen-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d76b23fd9cbb4d078d0dc063649c0467</projectId>-->
<!--<branchName>zen-verse</branchName>-->